### PR TITLE
Use native tools and LLVM on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,19 @@ endif
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-LD           = x86_64-w64-mingw32-ld
+LD           = lld-link
 CC           = clang
 CXX          = clang++
+CGC          = cgc
 endif
 ifeq ($(UNAME_S),Darwin)
 LD           = /usr/local/opt/llvm/bin/lld -flavor link
 CC           = /usr/local/opt/llvm/bin/clang
 CXX          = /usr/local/opt/llvm/bin/clang++
+CGC          = wine $(NXDK_DIR)/tools/cg/cgc.exe
 endif
 
 TARGET       = $(OUTPUT_DIR)/default.xbe
-CGC          = wine $(NXDK_DIR)/tools/cg/cgc.exe
 CXBE         = $(NXDK_DIR)/tools/cxbe/cxbe
 VP20COMPILER = $(NXDK_DIR)/tools/vp20compiler/vp20compiler
 FP20COMPILER = $(NXDK_DIR)/tools/fp20compiler/fp20compiler
@@ -80,7 +81,7 @@ endif
 main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ LD       ] $@"
 ifeq ($(UNAME_S),Linux)
-	$(VE) $(LD) -m i386pe -shared --entry=_XboxCRT -o $@ $^
+	$(VE) $(LD) -subsystem:windows -dll -out:'$@' -entry:XboxCRT $^
 endif
 ifeq ($(UNAME_S),Darwin)
 	$(VE) $(LD) -subsystem:windows -dll -out:'$@' -entry:XboxCRT $^


### PR DESCRIPTION
With LLVM 4.x approaching most linux distros I figured we should use it as default on linux.
(I couldn't get mingw to work with NXDK anyway)
One major annoyance is that we don't have C++ support yet. So if it's easier to get that working with OpenXDK style mingw I'd be willing to switch this back.

[cgc has a binary available on Linux](https://developer.nvidia.com/cg-toolkit-download). So I decided to use that directly.