### PR TITLE
Fix networking code bug / crash introduced by #4

### DIFF
--- a/lib/net/nforceif/src/sys_arch.c
+++ b/lib/net/nforceif/src/sys_arch.c
@@ -401,12 +401,10 @@ sys_sem_signal(struct sys_sem **s)
 static void
 sys_sem_free_internal(struct sys_sem *sem)
 {
-  // FIXME! This will leak.
-
-  // NTSTATUS status = NtClose((void*)sem->handle);
-  // if (NT_SUCCESS(status)) {
-  //     abort();
-  // }
+  NTSTATUS status = NtClose((void*)sem->handle);
+  if (!NT_SUCCESS(status)) {
+      abort();
+  }
   free(sem);
 }
 

--- a/lib/net/nforceif/src/sys_arch.c
+++ b/lib/net/nforceif/src/sys_arch.c
@@ -83,16 +83,7 @@ int errno;
 u32_t
 sys_now(void)
 {
-  unsigned int now, freq = 733000;
-
-  /* Read TSC into EDX:EAX, then divide TSC by processor freq / 1000 to
-   * get elapsed milliseconds since reset (roughly).
-   */
-  asm __volatile__ ("rdtsc; divl %1"
-                    : "=a" (now)
-                    : "r" (freq)
-                    : "%edx");
-  return now;
+  return KeTickCount;
 }
 
 void


### PR DESCRIPTION
#4 caused random crashes / hangs after about 10 minutes if the network code was active (See https://github.com/xqemu/nxdk/pull/4/files#r112821109 ).
This fixes it by implementing `sys_now` using `KeTickCount`.

---

Additionally this activates the `NtClose` to avoid leaking created semaphores.
The original commented out code had the `NT_SUCCESS` check negated (accidentally?) and always caused `abort`.
I'm assuming this negated condition was the original reason for the code being commented out.

---

(Only tested in xqemu yet, I'll test on hw later)