### PR TITLE
Add Support for compiling on Windows (using MSYS2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.d
 _*.cpp
 _*.h
+!tools/cg/win/cgc.exe

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ CC           = /usr/local/opt/llvm/bin/clang
 CXX          = /usr/local/opt/llvm/bin/clang++
 CGC          = $(NXDK_DIR)/tools/cg/mac/cgc
 endif
+ifneq (,$(findstring MSYS_NT,$(UNAME_S)))
+LD           = lld-link
+CC           = clang
+CXX          = clang++
+CGC          = $(NXDK_DIR)/tools/cg/win/cgc
+endif
 
 TARGET       = $(OUTPUT_DIR)/default.xbe
 CXBE         = $(NXDK_DIR)/tools/cxbe/cxbe

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ On OS X with [Homebrew](http://brew.sh/), this should do the job (XCode ships wi
 
 Then install lld from an [LLVM nightly package](http://apt.llvm.org/)
 
+#### Windows
+Install [MSYS2](http://www.msys2.org/)
+
+In MSYS2 Shell:
+
+    pacman -S make git gcc bison flex llvm clang
+
 ### Download nxdk
     git clone https://github.com/xqemu/nxdk.git
     cd nxdk

--- a/tools/vp20compiler/Makefile
+++ b/tools/vp20compiler/Makefile
@@ -8,7 +8,7 @@ SRCS = nvvertparse.c \
 
 OBJS = $(SRCS:.c=.o)
 
-CFLAGS = -std=c99
+CFLAGS = -std=gnu99
 
 $(MAIN): $(OBJS)
 	$(CC) -o '$@' $(OBJS)


### PR DESCRIPTION
This allows nxdk to be used on Windows using the MSYS2 shell.

Known Issues:
 - Currently LLVM needs to be installed separately as the MSYS2 package is still on LLVM 3.9, as soon as LLVM 4.0 ships in MSYS2, this will no longer be required (this is why it is not mentioned in the readme)
 - extract-xiso does not compile under MSYS2.
