### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,16 @@ VP20COMPILER = $(NXDK_DIR)/tools/vp20compiler/vp20compiler
 FP20COMPILER = $(NXDK_DIR)/tools/fp20compiler/fp20compiler
 EXTRACT_XISO = $(NXDK_DIR)/tools/extract-xiso/extract-xiso
 TOOLS        = cxbe vp20compiler fp20compiler extract-xiso
-CFLAGS       = -target i386-pc-win32 -march=pentium3 \
+NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -ffreestanding -nostdlib -fno-builtin -fno-exceptions \
                -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt \
-               -Wno-ignored-attributes
+               -Wno-ignored-attributes -DNXDK
 
 ifeq ($(DEBUG),y)
-CFLAGS += -g
+NXDK_CFLAGS += -g
 endif
+
+NXDK_CFLAGS += $(CFLAGS)
 
 include $(NXDK_DIR)/lib/Makefile
 OBJS = $(SRCS:.c=.obj)
@@ -88,12 +90,12 @@ main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 
 %.obj: %.c
 	@echo "[ CC       ] $@"
-	$(VE) $(CC) $(CFLAGS) -c -o '$@' '$<'
+	$(VE) $(CC) $(NXDK_CFLAGS) -c -o '$@' '$<'
 
 %.c.d: %.c
 	@echo "[ DEP      ] $@"
 	$(VE) set -e; rm -f $@; \
-	$(CC) -M -MM -MG -MT '$*.obj' -MF $@ $(CFLAGS) $<; \
+	$(CC) -M -MM -MG -MT '$*.obj' -MF $@ $(NXDK_CFLAGS) $<; \
 	echo "\n$@ : $^\n" >> $@
 
 %.inl: %.vs.cg $(VP20COMPILER)


### PR DESCRIPTION
* ~~I had issues where the deps were outdated or my project folders were full of *.d files. This branch cleans the dep on `make clean`.~~
* Code should have a way to identify that it's being build using NXDK. This adds a NXDK preprocessor macro, we should also consider defining XBOX or something in the future.
* As the makefile is included, we need a way to add more CFLAGS (to add more include directories, preprocessor defines etc.). This branch renames our CFLAGS to NXDK_CFLAGS and appends existing CFLAGS to the end.

The integration of the last change is not the best. But I hate makefiles and can't be bothered to figure out how to do this properly - this get's the job done (I think).